### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Two middleware classes are available:
 (You should only use one at a time, otherwise that will be quite confusing)
 
 ```ruby
+require "sidekiq_profiling_middleware/stack_prof"
+
 Sidekiq.configure_server do |config|
   ....
   config.server_middleware do |chain|


### PR DESCRIPTION
The required setup example in the README is different to https://medium.com/@callumj/introducing-sidekiq-profiling-middleware-a-tool-for-profiling-sidekiq-e00d6fc7cede, it's missing the `require` statement.

Just started playing around with this - nice work!